### PR TITLE
iam roles output added

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,12 +85,12 @@ Available targets:
 |------|-------------|
 | bastion_security_group_arn | Bastion server Security Group ARN |
 | bastion_security_group_id | Bastion server Security Group ID |
-| masters_role_arn | K8s nodes Security Group ID |
-| masters_role_name | K8s nodes Security Group ARN |
+| masters_role_arn | kops masters IAM Role ARN |
+| masters_role_name | kops masters IAM Role name |
 | masters_security_group_arn | kops masters Security Group ARN |
 | masters_security_group_id | kops masters Security Group ID |
-| nodes_role_arn | Kops nodes Role ARN |
-| nodes_role_name | Kops nodes Role name |
+| nodes_role_arn | kops nodes IAM Role ARN |
+| nodes_role_name | kops nodes IAM Role name |
 | nodes_security_group_arn | kops nodes Security Group ARN |
 | nodes_security_group_id | kops nodes Security Group ID |
 | private_subnet_ids | Private subnet IDs in the VPC |

--- a/README.md
+++ b/README.md
@@ -42,6 +42,11 @@ We literally have [*hundreds of terraform modules*][terraform_modules] that are 
 
 ## Usage
 
+
+**IMPORTANT:** The `master` branch is used in `source` just as an example. In your code, do not pin to `master` because there may be breaking changes between releases.
+Instead pin to the release tag (e.g. `?ref=tags/x.y.z`) of one of our [latest releases](https://github.com/cloudposse/terraform-aws-kops-data-network/releases).
+
+
 ```hcl
 module "kops_metadata" {
   source       = "git::https://github.com/cloudposse/terraform-aws-kops-data-network.git?ref=master"
@@ -80,8 +85,12 @@ Available targets:
 |------|-------------|
 | bastion_security_group_arn | Bastion server Security Group ARN |
 | bastion_security_group_id | Bastion server Security Group ID |
+| masters_role_arn | K8s nodes Security Group ID |
+| masters_role_name | K8s nodes Security Group ARN |
 | masters_security_group_arn | kops masters Security Group ARN |
 | masters_security_group_id | kops masters Security Group ID |
+| nodes_role_arn | Kops nodes Role ARN |
+| nodes_role_name | Kops nodes Role name |
 | nodes_security_group_arn | kops nodes Security Group ARN |
 | nodes_security_group_id | kops nodes Security Group ID |
 | private_subnet_ids | Private subnet IDs in the VPC |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -12,8 +12,12 @@
 |------|-------------|
 | bastion_security_group_arn | Bastion server Security Group ARN |
 | bastion_security_group_id | Bastion server Security Group ID |
+| masters_role_arn | K8s nodes Security Group ID |
+| masters_role_name | K8s nodes Security Group ARN |
 | masters_security_group_arn | kops masters Security Group ARN |
 | masters_security_group_id | kops masters Security Group ID |
+| nodes_role_arn | Kops nodes Role ARN |
+| nodes_role_name | Kops nodes Role name |
 | nodes_security_group_arn | kops nodes Security Group ARN |
 | nodes_security_group_id | kops nodes Security Group ID |
 | private_subnet_ids | Private subnet IDs in the VPC |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -12,12 +12,12 @@
 |------|-------------|
 | bastion_security_group_arn | Bastion server Security Group ARN |
 | bastion_security_group_id | Bastion server Security Group ID |
-| masters_role_arn | K8s nodes Security Group ID |
-| masters_role_name | K8s nodes Security Group ARN |
+| masters_role_arn | kops masters IAM Role ARN |
+| masters_role_name | kops masters IAM Role name |
 | masters_security_group_arn | kops masters Security Group ARN |
 | masters_security_group_id | kops masters Security Group ID |
-| nodes_role_arn | Kops nodes Role ARN |
-| nodes_role_name | Kops nodes Role name |
+| nodes_role_arn | kops nodes IAM Role ARN |
+| nodes_role_name | kops nodes IAM Role name |
 | nodes_security_group_arn | kops nodes Security Group ARN |
 | nodes_security_group_id | kops nodes Security Group ID |
 | private_subnet_ids | Private subnet IDs in the VPC |

--- a/main.tf
+++ b/main.tf
@@ -65,3 +65,11 @@ data "aws_security_group" "nodes" {
     Name = "nodes.${var.cluster_name}"
   }
 }
+
+data "aws_iam_role" "masters" {
+  name = "masters.${var.cluster_name}"
+}
+
+data "aws_iam_role" "nodes" {
+  name = "nodes.${var.cluster_name}"
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -55,7 +55,7 @@ output "masters_role_arn" {
 
 output "nodes_role_name" {
   value       = "${data.aws_iam_role.nodes.id}"
-  description = "Kops nodes Role name"
+  description = "Kops nodes IAM Role name"
 }
 
 output "nodes_role_arn" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -50,7 +50,7 @@ output "masters_role_name" {
 
 output "masters_role_arn" {
   value       = "${data.aws_iam_role.masters.arn}"
-  description = "K8s nodes Security Group ID"
+  description = "Kops masters IAM Role ARN"
 }
 
 output "nodes_role_name" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -42,3 +42,23 @@ output "nodes_security_group_id" {
   value       = "${join("", data.aws_security_group.nodes.*.id)}"
   description = "kops nodes Security Group ID"
 }
+
+output "masters_role_name" {
+  value       = "${data.aws_iam_role.masters.id}"
+  description = "K8s nodes Security Group ARN"
+}
+
+output "masters_role_arn" {
+  value       = "${data.aws_iam_role.masters.arn}"
+  description = "K8s nodes Security Group ID"
+}
+
+output "nodes_role_name" {
+  value       = "${data.aws_iam_role.nodes.id}"
+  description = "Kops nodes Role name"
+}
+
+output "nodes_role_arn" {
+  value       = "${data.aws_iam_role.nodes.arn}"
+  description = "Kops nodes Role ARN"
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -60,5 +60,5 @@ output "nodes_role_name" {
 
 output "nodes_role_arn" {
   value       = "${data.aws_iam_role.nodes.arn}"
-  description = "Kops nodes IAM Role ARN"
+  description = "kops nodes IAM Role ARN"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -45,7 +45,7 @@ output "nodes_security_group_id" {
 
 output "masters_role_name" {
   value       = "${data.aws_iam_role.masters.id}"
-  description = "Masters IAM Role name"
+  description = "kops masters IAM Role name"
 }
 
 output "masters_role_arn" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -50,7 +50,7 @@ output "masters_role_name" {
 
 output "masters_role_arn" {
   value       = "${data.aws_iam_role.masters.arn}"
-  description = "Kops masters IAM Role ARN"
+  description = "kops masters IAM Role ARN"
 }
 
 output "nodes_role_name" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -45,7 +45,7 @@ output "nodes_security_group_id" {
 
 output "masters_role_name" {
   value       = "${data.aws_iam_role.masters.id}"
-  description = "K8s nodes Security Group ARN"
+  description = "Masters IAM Role name"
 }
 
 output "masters_role_arn" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -60,5 +60,5 @@ output "nodes_role_name" {
 
 output "nodes_role_arn" {
   value       = "${data.aws_iam_role.nodes.arn}"
-  description = "Kops nodes Role ARN"
+  description = "Kops nodes IAM Role ARN"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -55,7 +55,7 @@ output "masters_role_arn" {
 
 output "nodes_role_name" {
   value       = "${data.aws_iam_role.nodes.id}"
-  description = "Kops nodes IAM Role name"
+  description = "kops nodes IAM Role name"
 }
 
 output "nodes_role_arn" {


### PR DESCRIPTION
what
* output with iam roles id and arn added for masters and nodes

why
*  It will make this module usable instead of `terraform-aws-kops-metadata` where it is needed (because of new way of tagging VPCs)